### PR TITLE
Update to jacoco 0.8.3 for Kotlin support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
See issue 31

I can execute pitest using gradle and pitest gradle plugin successfully. When I attempt to send to sonarqube I get

Line 44 is out of range in the file src/main/kotlin/com/<some package>/Runner.kt (lines: 43)

I traced this to a Jacoco issue. To resolve this, the version should be updated to 0.8.3 in the pom.xml

I am running against sonarqube 7.6 with the latest version of the sonar pitest plugin