### PR TITLE
Pitest 1.7.0 support

### DIFF
--- a/src/main/java/ch/devcon5/sonar/plugins/mutationanalysis/model/Mutant.java
+++ b/src/main/java/ch/devcon5/sonar/plugins/mutationanalysis/model/Mutant.java
@@ -574,8 +574,9 @@ public class Mutant {
          if (mutationOperator == MutationOperators.UNKNOWN) {
             LOGGER.warn("Found unknown mutation operator: {}", mutagenName);
             mutatorSuffix = "";
-         } else if (mutagenName.startsWith(mutationOperator.getClassName())) {
-            mutatorSuffix = mutagenName.substring(mutationOperator.getClassName().length());
+         } else if (mutationOperator.getClassNames().stream().anyMatch(mutagenName::startsWith)) {
+            final String mutatorClassName = mutationOperator.getClassNames().stream().filter(mutagenName::startsWith).findAny().get();
+            mutatorSuffix = mutagenName.substring(mutatorClassName.length());
          } else {
             mutatorSuffix = "";
          }

--- a/src/main/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperator.java
+++ b/src/main/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperator.java
@@ -24,7 +24,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,11 +51,11 @@ public final class MutationOperator {
     private final URL mutagenDescLoc;
     private final String violationDesc;
     private final String name;
-    private final String className;
+    private final Set<String> classNames;
 
     MutationOperator(final String id,
                      final String name,
-                     final String className,
+                     final Collection<String> classNames,
                      final String violationDesc,
                      final URL mutagenDescriptionLocation) {
 
@@ -59,7 +64,7 @@ public final class MutationOperator {
         requireNonNull(violationDesc, "violation description must not be null");
         this.id = id;
         this.name = name;
-        this.className = className;
+        this.classNames = new HashSet<>(requireNonNull(classNames, "classNames must not be null"));
         this.violationDesc = violationDesc;
         this.mutagenDescLoc = mutagenDescriptionLocation;
     }
@@ -111,13 +116,12 @@ public final class MutationOperator {
     }
 
     /**
-     * The fully qualified classname of the {@link MutationOperator} class.
+     * The fully qualified classnames of the {@link MutationOperator} class.
      *
-     * @return the classname
+     * @return the classnames
      */
-    public String getClassName() {
-
-        return className;
+    public Set<String> getClassNames() {
+        return Collections.unmodifiableSet(classNames);
     }
 
     /**

--- a/src/main/resources/ch/devcon5/sonar/plugins/mutationanalysis/model/mutagen-def.xml
+++ b/src/main/resources/ch/devcon5/sonar/plugins/mutationanalysis/model/mutagen-def.xml
@@ -28,6 +28,7 @@
         <operatorDescription classpath="ARGUMENT_PROPAGATION.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</class>
         </classes>
     </operator>
     <operator id="BOOLEAN_FALSE_RETURN">
@@ -38,6 +39,7 @@
         <operatorDescription classpath="BOOLEAN_FALSE_RETURN.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.BooleanFalseReturnValsMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanFalseReturnValsMutator</class>
         </classes>
     </operator>
     <operator id="BOOLEAN_TRUE_RETURN">
@@ -48,6 +50,7 @@
         <operatorDescription classpath="BOOLEAN_TRUE_RETURN.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.BooleanTrueReturnValsMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</class>
         </classes>
     </operator>
     <operator id="CONDITIONALS_BOUNDARY">
@@ -78,6 +81,7 @@
         <operatorDescription classpath="EMPTY_RETURN_VALUES.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.EmptyObjectReturnValsMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</class>
         </classes>
     </operator>
     <operator id="INCREMENTS">
@@ -148,6 +152,7 @@
         <operatorDescription classpath="NULL_RETURN_VALUES.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</class>
         </classes>
     </operator>
     <operator id="PRIMITIVE_RETURN_VALS">
@@ -158,6 +163,7 @@
         <operatorDescription classpath="PRIMITIVE_RETURN_VALS.html"/>
         <classes>
             <class>org.pitest.mutationtest.engine.gregor.mutators.PrimitiveReturnsMutator</class>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.returns.PrimitiveReturnsMutator</class>
         </classes>
     </operator>
     <operator id="REMOVE_CONDITIONALS">

--- a/src/main/resources/ch/devcon5/sonar/plugins/mutationanalysis/model/mutagen-def.xml
+++ b/src/main/resources/ch/devcon5/sonar/plugins/mutationanalysis/model/mutagen-def.xml
@@ -20,194 +20,234 @@
   -->
 
 <operators>
-    <operator
-            id="ARGUMENT_PROPAGATION"
-            class="org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator">
+    <operator id="ARGUMENT_PROPAGATION">
         <name>Argument Propagation Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A return value has been replaced by a method argument without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="ARGUMENT_PROPAGATION.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator</class>
+        </classes>
     </operator>
-    <operator
-            id="BOOLEAN_FALSE_RETURN"
-            class="org.pitest.mutationtest.engine.gregor.mutators.BooleanFalseReturnValsMutator">
+    <operator id="BOOLEAN_FALSE_RETURN">
         <name>Boolean False Return Vals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A primitive or boxed boolean has been replaced with false without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="BOOLEAN_FALSE_RETURN.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.BooleanFalseReturnValsMutator</class>
+        </classes>
     </operator>
-    <operator
-            id="BOOLEAN_TRUE_RETURN"
-            class="org.pitest.mutationtest.engine.gregor.mutators.BooleanTrueReturnValsMutator">
+    <operator id="BOOLEAN_TRUE_RETURN">
         <name>Boolean True Return Vals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A primitive or boxed boolean has been replaced with true without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="BOOLEAN_TRUE_RETURN.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.BooleanTrueReturnValsMutator</class>
+        </classes>
     </operator>
-    <operator
-            id="CONDITIONALS_BOUNDARY"
-            class="org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator">
+    <operator id="CONDITIONALS_BOUNDARY">
         <name>Conditionals Boundary Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A relational operator has been replaced by a boundary counterpart without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="CONDITIONALS_BOUNDARY.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator</class>
+        </classes>
     </operator>
-    <operator id="CONSTRUCTOR_CALLS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator">
+    <operator id="CONSTRUCTOR_CALLS">
         <name>Constructor Call Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A constructor call has been removed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="CONSTRUCTOR_CALLS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator</class>
+        </classes>
     </operator>
-    <operator
-            id="EMPTY_RETURN_VALUES"
-            class="org.pitest.mutationtest.engine.gregor.mutators.EmptyObjectReturnValsMutator">
+    <operator id="EMPTY_RETURN_VALUES">
         <name>Empty Object Return Vals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: An object return value has been replaced with it's empty counterpart without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="EMPTY_RETURN_VALUES.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.EmptyObjectReturnValsMutator</class>
+        </classes>
     </operator>
-    <operator id="INCREMENTS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.IncrementsMutator">
+    <operator id="INCREMENTS">
         <name>Increments Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A local variable increment/decrement has been replaced without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="INCREMENTS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.IncrementsMutator</class>
+        </classes>
     </operator>
-    <operator id="INLINE_CONSTS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.InlineConstantMutator">
+    <operator id="INLINE_CONSTS">
         <name>Inline Constant Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: An inline constant has been changed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="INLINE_CONSTS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.InlineConstantMutator</class>
+        </classes>
     </operator>
-    <operator id="INVERT_NEGS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.InvertNegsMutator">
+    <operator id="INVERT_NEGS">
         <name>Invert Negs Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A number has been replaced by its opposite without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="INVERT_NEGS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.InvertNegsMutator</class>
+        </classes>
     </operator>
-    <operator id="MATH"
-             class="org.pitest.mutationtest.engine.gregor.mutators.MathMutator">
+    <operator id="MATH">
         <name>Math Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A binary arithmetic operation has been replaced by another one without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="MATH.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.MathMutator</class>
+        </classes>
     </operator>
-    <operator id="NEGATE_CONDITIONALS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator">
+    <operator id="NEGATE_CONDITIONALS">
         <name>Negate Conditionals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A conditional expression has been negated without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="NEGATE_CONDITIONALS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</class>
+        </classes>
     </operator>
-    <operator id="NON_VOID_METHOD_CALLS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator">
+    <operator id="NON_VOID_METHOD_CALLS">
         <name>Non Void Method Call Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A method call has been removed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="NON_VOID_METHOD_CALLS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</class>
+        </classes>
     </operator>
-    <operator id="NULL_RETURN_VALUES"
-            class="org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator">
+    <operator id="NULL_RETURN_VALUES">
         <name>Null Return Vals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A non-primitive return value has been replaced with null without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="NULL_RETURN_VALUES.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator</class>
+        </classes>
     </operator>
-    <operator id="PRIMITIVE_RETURN_VALS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.PrimitiveReturnsMutator">
+    <operator id="PRIMITIVE_RETURN_VALS">
         <name>Primitive Returns Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A primitive number return value has been replaced with 0 without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="PRIMITIVE_RETURN_VALS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.PrimitiveReturnsMutator</class>
+        </classes>
     </operator>
-    <operator id="REMOVE_CONDITIONALS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator">
+    <operator id="REMOVE_CONDITIONALS">
         <name>Remove Conditional Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A condition has been removed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="REMOVE_CONDITIONALS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator</class>
+        </classes>
     </operator>
-    <operator id="RETURN_VALS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator">
+    <operator id="RETURN_VALS">
         <name>Return Vals Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: The return value of a method call has been replaced without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="RETURN_VALS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</class>
+        </classes>
     </operator>
-    <operator id="VOID_METHOD_CALLS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator">
+    <operator id="VOID_METHOD_CALLS">
         <name>Void Method Call Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A method call has been removed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="VOID_METHOD_CALLS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</class>
+        </classes>
     </operator>
-    <operator id="EXPERIMENTAL_MEMBER_VARIABLE"
-             class="org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator">
+    <operator id="EXPERIMENTAL_MEMBER_VARIABLE">
         <name>Member Variable Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A member variable assignment has been replaced without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_MEMBER_VARIABLE.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</class>
+        </classes>
     </operator>
-    <operator
-            id="EXPERIMENTAL_NAKED_RECEIVER"
-            class="org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator">
+    <operator id="EXPERIMENTAL_NAKED_RECEIVER">
         <name>Naked Receiver Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A non-void method call has been removed and replaced with it's receiver without being detected by a test]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_NAKED_RECEIVER.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</class>
+        </classes>
     </operator>
-    <operator id="EXPERIMENTAL_REMOVE_INCREMENTS"
-             class="org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveIncrementsMutator">
+    <operator id="EXPERIMENTAL_REMOVE_INCREMENTS">
         <name>Remove Increments Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: An increment operation has been removed without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_REMOVE_INCREMENTS.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveIncrementsMutator</class>
+        </classes>
     </operator>
-    <operator id="EXPERIMENTAL_REMOVE_SWITCH"
-             class="org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator">
+    <operator id="EXPERIMENTAL_REMOVE_SWITCH">
         <name>Remove Switch Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A switch statement has been replaced with the default label without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_REMOVE_SWITCH.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator</class>
+        </classes>
     </operator>
-    <operator id="EXPERIMENTAL_RETURN_VALUES"
-             class="org.pitest.mutationtest.engine.gregor.mutators.experimental.ReturnValuesMutator">
+    <operator id="EXPERIMENTAL_RETURN_VALUES">
         <name>Return Values Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: A return value has been replaced without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_RETURN_VALUES.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.ReturnValuesMutator</class>
+        </classes>
     </operator>
-    <operator id="EXPERIMENTAL_SWITCH"
-             class="org.pitest.mutationtest.engine.gregor.mutators.experimental.SwitchMutator">
+    <operator id="EXPERIMENTAL_SWITCH">
         <name>Switch Mutator</name>
         <violationDescription>
             <![CDATA[Alive Mutant: The default label has been replaced without being detected by a test.]]>
         </violationDescription>
         <operatorDescription classpath="EXPERIMENTAL_SWITCH.html"/>
+        <classes>
+            <class>org.pitest.mutationtest.engine.gregor.mutators.experimental.SwitchMutator</class>
+        </classes>
     </operator>
 </operators>

--- a/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorTest.java
+++ b/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorTest.java
@@ -25,6 +25,8 @@ import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
 
 import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -131,7 +133,12 @@ public class MutationOperatorTest {
       final MutationOperator mutationOperator = MutationOperators.find("ARGUMENT_PROPAGATION");
       final Set<String> classNames = mutationOperator.getClassNames();
       assertEquals(
-          singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+          new HashSet<>(
+              Arrays.asList(
+                  "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                  "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+              )
+          ),
           classNames);
    }
 

--- a/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorTest.java
+++ b/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorTest.java
@@ -20,10 +20,13 @@
 
 package ch.devcon5.sonar.plugins.mutationanalysis.model;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
 
 import java.net.URL;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -33,32 +36,39 @@ public class MutationOperatorTest {
    @Test(expected = NullPointerException.class)
    public void testMutator_nullId_exception() throws Exception {
 
-      new MutationOperator(null, "", "", "", new URL("file:///"));
+      new MutationOperator(null, "", emptySet(), "", new URL("file:///"));
 
    }
 
    @Test(expected = NullPointerException.class)
    public void testMutator_nullName_exception() throws Exception {
 
-      new MutationOperator("", null, "", "", new URL("file:///"));
+      new MutationOperator("", null, emptySet(), "", new URL("file:///"));
+
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testMutator_nullClassNames_exception() throws Exception {
+
+      new MutationOperator("", "", null, "", new URL("file:///"));
 
    }
 
    @Test(expected = NullPointerException.class)
    public void testMutator_nullViolationDescription_exception() throws Exception {
 
-      new MutationOperator("", "", "", null, new URL("file:///"));
+      new MutationOperator("", "", emptySet(), null, new URL("file:///"));
 
    }
 
    @Test
    public void testMutator_nullArguments() throws Exception {
 
-      final MutationOperator mutationOperator = new MutationOperator("id", "name", null, "violationDescription", null);
+      final MutationOperator mutationOperator = new MutationOperator("id", "name", emptySet(), "violationDescription", null);
       assertEquals("id", mutationOperator.getId());
       assertEquals("name", mutationOperator.getName());
       assertEquals("violationDescription", mutationOperator.getViolationDescription());
-      assertNull(mutationOperator.getClassName());
+      assertEquals(emptySet(), mutationOperator.getClassNames());
       assertNotNull(mutationOperator.getMutagenDescriptionLocation());
       assertFalse(mutationOperator.getMutagenDescriptionLocation().isPresent());
       assertNotNull(mutationOperator.getMutagenDescriptionLocation());
@@ -94,7 +104,7 @@ public class MutationOperatorTest {
    @Test
    public void testGetMutatorDescription_exceptionOccured_noDescription() throws Exception {
 
-      final MutationOperator mutationOperator = new MutationOperator("test", "aName", "aClass", "aViolationDescription", new URL("file://localhost:1"));
+      final MutationOperator mutationOperator = new MutationOperator("test", "aName", singleton("aClass"), "aViolationDescription", new URL("file://localhost:1"));
       final String desc = mutationOperator.getMutagenDescription();
       assertEquals("No description", desc);
    }
@@ -116,19 +126,21 @@ public class MutationOperatorTest {
    }
 
    @Test
-   public void testGetClassName() throws Exception {
+   public void testGetClassNames() throws Exception {
 
       final MutationOperator mutationOperator = MutationOperators.find("ARGUMENT_PROPAGATION");
-      final String className = mutationOperator.getClassName();
-      assertEquals("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator", className);
+      final Set<String> classNames = mutationOperator.getClassNames();
+      assertEquals(
+          singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+          classNames);
    }
 
    @Test
-   public void testGetClassName_fromCustomOperator() throws Exception {
+   public void testGetClassNames_fromCustomOperator() throws Exception {
 
-      final MutationOperator mutationOperator = new MutationOperator("test", "aName", "aClass", "aViolationDescription", new URL("file://localhost:1"));
-      final String className = mutationOperator.getClassName();
-      assertEquals("aClass", className);
+      final MutationOperator mutationOperator = new MutationOperator("test", "aName", singleton("aClass"), "aViolationDescription", new URL("file://localhost:1"));
+      final Set<String> classNames = mutationOperator.getClassNames();
+      assertEquals(singleton("aClass"), classNames);
    }
 
    @Test
@@ -164,7 +176,7 @@ public class MutationOperatorTest {
    public void testEquals_equalsId_true() throws Exception {
 
       final MutationOperator argumentPropagation = MutationOperators.find("ARGUMENT_PROPAGATION");
-      final MutationOperator other = new MutationOperator("ARGUMENT_PROPAGATION", "someName", "someClass", "someDescription", new URL("file:///"));
+      final MutationOperator other = new MutationOperator("ARGUMENT_PROPAGATION", "someName", singleton("someClass"), "someDescription", new URL("file:///"));
       assertEquals(argumentPropagation, other);
    }
 

--- a/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorsTest.java
+++ b/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorsTest.java
@@ -20,6 +20,7 @@
 
 package ch.devcon5.sonar.plugins.mutationanalysis.model;
 
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -39,8 +40,9 @@ public class MutationOperatorsTest {
         final MutationOperator mutationOperator = MutationOperators.find("ARGUMENT_PROPAGATION");
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
-        assertEquals("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
-                     mutationOperator.getClassName());
+        assertEquals(
+            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }
 
@@ -51,8 +53,9 @@ public class MutationOperatorsTest {
                 .find("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator");
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
-        assertEquals("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
-                     mutationOperator.getClassName());
+        assertEquals(
+            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }
 
@@ -63,8 +66,9 @@ public class MutationOperatorsTest {
                 .find("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator_WITH_SUFFIX");
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
-        assertEquals("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
-                     mutationOperator.getClassName());
+        assertEquals(
+            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }
 

--- a/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorsTest.java
+++ b/src/test/java/ch/devcon5/sonar/plugins/mutationanalysis/model/MutationOperatorsTest.java
@@ -25,7 +25,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.junit.Test;
 
@@ -41,7 +43,12 @@ public class MutationOperatorsTest {
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
         assertEquals(
-            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            new HashSet<>(
+                Arrays.asList(
+                    "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                    "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+                )
+            ),
             mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }
@@ -54,7 +61,30 @@ public class MutationOperatorsTest {
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
         assertEquals(
-            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            new HashSet<>(
+                Arrays.asList(
+                    "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                    "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+                )
+            ),
+            mutationOperator.getClassNames());
+        assertNotNull(mutationOperator.getViolationDescription());
+    }
+
+    @Test
+    public void testFind_knownMutator_byClassName_v2() throws Exception {
+
+        final MutationOperator mutationOperator = MutationOperators
+            .find("org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator");
+        assertNotNull(mutationOperator);
+        assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
+        assertEquals(
+            new HashSet<>(
+                Arrays.asList(
+                    "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                    "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+                )
+            ),
             mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }
@@ -67,7 +97,30 @@ public class MutationOperatorsTest {
         assertNotNull(mutationOperator);
         assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
         assertEquals(
-            singleton("org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator"),
+            new HashSet<>(
+                Arrays.asList(
+                    "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                    "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+                )
+            ),
+            mutationOperator.getClassNames());
+        assertNotNull(mutationOperator.getViolationDescription());
+    }
+
+    @Test
+    public void testFind_knownMutator_byClassNameWithSuffix_v2() throws Exception {
+
+        final MutationOperator mutationOperator = MutationOperators
+            .find("org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator_WITH_SUFFIX");
+        assertNotNull(mutationOperator);
+        assertEquals("ARGUMENT_PROPAGATION", mutationOperator.getId());
+        assertEquals(
+            new HashSet<>(
+                Arrays.asList(
+                    "org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator",
+                    "org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator"
+                )
+            ),
             mutationOperator.getClassNames());
         assertNotNull(mutationOperator.getViolationDescription());
     }


### PR DESCRIPTION
Pitest merged support for pluggable mutators in v1.7.0 and as part of this change they renamed some of built-in mutators. This results in mutation-analysis-plugin not being able to recognize mutations when parsing Pitest reports:
```
[INFO] Sensor Mutation Analysis [mutationanalysis]
[INFO] Pitest Sensor [java, kotlin] running on [key=com.revere.basics:commons] in /home/agrigorov02/git/basics/commons
[WARNING] Found unknown mutation operator: org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator
[WARNING] Found unknown mutation operator: org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator
[WARNING] Found unknown mutation operator: org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanFalseReturnValsMutator
[WARNING] Found unknown mutation operator: org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator
...
```

At the same time just updating class names wouldn't work for my usecase, as some projects are still using older versions of pitest (mostly v1.6.9, but some are still on v1.5.2).

This PR changes `MutationOperator` class to support specifying multiple class names, updates `mutagen-def.xml` and tests accordingly and then adds new class names for Pitest v1.7.0 mutators in separate commit.

I tested these changes on my instance of Sonarqube and all seems good so far.